### PR TITLE
人口構成一覧取得にdebounceをかける

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,5 +22,5 @@ export default defineNuxtConfig({
       },
     },
   },
-  modules: [[BasicAuth, { enabled: true }]],
+  modules: [[BasicAuth, { enabled: true }], 'nuxt-lodash'],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "apexcharts": "^3.41.0",
         "nuxt-basic-authentication-module": "^0.2.1",
+        "nuxt-lodash": "^2.5.0",
         "vue3-apexcharts": "^1.4.1"
       },
       "devDependencies": {
@@ -2565,6 +2566,19 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -8832,6 +8846,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10299,6 +10318,16 @@
       "dependencies": {
         "@nuxt/kit": "^3.0.0-rc.6",
         "basic-auth": "^2.0.1"
+      }
+    },
+    "node_modules/nuxt-lodash": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/nuxt-lodash/-/nuxt-lodash-2.5.0.tgz",
+      "integrity": "sha512-nd7YrKzJH7kqMEwyAlwk0T8Fi/G1heAaWJENFm6SUIwYgR6AOigp/ryLya+JBEP+ZmGrJbIHq+mhWNdvKsLK7g==",
+      "dependencies": {
+        "@nuxt/kit": "^3.6.0",
+        "@types/lodash-es": "^4.17.7",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/nypm": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "apexcharts": "^3.41.0",
     "nuxt-basic-authentication-module": "^0.2.1",
+    "nuxt-lodash": "^2.5.0",
     "vue3-apexcharts": "^1.4.1"
   }
 }

--- a/src/components/ChartSection.vue
+++ b/src/components/ChartSection.vue
@@ -1,12 +1,28 @@
 <template>
   <section class="chart-card">
     <div class="type">
-      <label v-for="(label, index) in labelList" :key="index" class="chart-radio" :for="label">
+      <label
+        v-for="(label, index) in labelList"
+        :key="index"
+        class="chart-radio"
+        :for="label"
+      >
         {{ label }}
-        <input :id="label" v-model="selectedLabel" type="radio" :value="label" />
+        <input
+          :id="label"
+          v-model="selectedLabel"
+          type="radio"
+          :value="label"
+        />
       </label>
     </div>
-    <apexchart width="100%" type="line" height="400" :options="chartOptions" :series="series"></apexchart>
+    <apexchart
+      width="100%"
+      type="line"
+      height="400"
+      :options="chartOptions"
+      :series="series"
+    ></apexchart>
   </section>
 </template>
 <script lang="ts" setup>
@@ -120,8 +136,8 @@ watch(
   prefectureState.checkedPrefecture,
   // 秒間リクエストに制限があるため、debounceをかける
   useDebounce(async (newCheck: Array<number>, oldCheck: Array<number>) => {
-    updatePopulation(newCheck, oldCheck);
-  }, 300)
+    await updatePopulation(newCheck, oldCheck);
+  }, 200)
 );
 
 watch(selectedLabel, () => {


### PR DESCRIPTION
# 概要
* 秒間5リクエストの制限があるため、過度に早い操作にはdebounceをかける

## 備考
* クリックからチャート表示までのまでのラグが気になるので、ローディング処理を入れたい